### PR TITLE
resolve installation issues for jaxlib and  isaacgym setuptools

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,14 @@ Download [IsaacGym Preview 4](https://developer.nvidia.com/isaac-gym) and instal
 
 ```bash
 cd <isaacgym_path>/python
+pip install "setuptools<67"
 pip install -e .
+```
+
+If you get `ImportError: libpython3.8.so.1.0: cannot open shared object file`, run this before importing isaacgym:
+
+```bash
+export LD_LIBRARY_PATH=/path/to/miniconda3/envs/viploco/lib:$LD_LIBRARY_PATH
 ```
 
 ---

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+--find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+
 # For jax
 flax==0.7.2
 optax==0.1.8


### PR DESCRIPTION
## Fix Installation Blockers for Isaac Gym Environment

This PR addresses three key installation blockers reported in issue #1:

### 1. `requirements.txt`
- Added the JAX CUDA releases index as a `--find-links` source.
- Ensures `jaxlib` resolves correctly during `pip install -r requirements.txt`.

### 2. `pip install -e .` for Isaac Gym
- Added a `pip install "setuptools<67"` step.
- Fixes the `canonicalize_version()` crash caused by newer versions of `setuptools`.

### 3. `import isaacgym` shared library error
- Documented the `LD_LIBRARY_PATH` fix for `libpython3.8.so.1.0` not found.
- Added instructions in the README for smooth runtime setup.

### Tested Configuration
- GPU: RTX 4090  
- Driver: 580  
- CUDA: 12.1  
- Python: 3.8  

 All packages import successfully after applying these changes.  
